### PR TITLE
Authorization header

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -476,6 +476,7 @@ def query_api(version: int = 1) -> Response:
                 # If a voice locale other than Icelandic is requested,
                 # use the default voice for that locale.
                 vid = voice_for_locale(result["voice_locale"])
+            result["voice_id"] = vid
             # Create audio data
             url = text_to_audio_url(v, voice_id=vid, speed=voice_speed)
             if url:

--- a/routes/api.py
+++ b/routes/api.py
@@ -472,7 +472,9 @@ def query_api(version: int = 1) -> Response:
             vid = voice_id
             if "voice_id" in result:
                 vid = result["voice_id"]
-            elif "voice_locale" in result:
+            elif "voice_locale" in result and result["voice_locale"] != "is_IS":
+                # If a voice locale other than Icelandic is requested,
+                # use the default voice for that locale.
                 vid = voice_for_locale(result["voice_locale"])
             # Create audio data
             url = text_to_audio_url(v, voice_id=vid, speed=voice_speed)

--- a/routes/main.py
+++ b/routes/main.py
@@ -176,7 +176,7 @@ TableType = List[List[Tuple[int, Any]]]
 
 
 @routes.route("/treegrid", methods=["GET"])
-def tree_grid() -> Response:
+def tree_grid() -> Union[Response,str]:
     """Show a simplified parse tree for a single sentence"""
 
     txt = request.args.get("txt", "")
@@ -426,7 +426,7 @@ def image() -> Response:
 @cache.cached(timeout=30 * 60, key_prefix="suggest", query_string=True)
 def suggest(limit: int=10) -> Response:
     """Return suggestions for query field autocompletion"""
-    limit = request.args.get("limit", limit)
+    limit = int(request.args.get("limit", limit))
     txt = request.args.get("q", "").strip()
 
     suggestions: List[Dict[str, str]] = []

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -110,7 +110,8 @@ def qmcall(
     assert "answer" in json
     if "voice" in qdict and qdict["voice"]:
         assert "voice" in json
-
+        assert "voice_id" in json
+        assert "voice_locale" in json
     if qtype is not None:
         assert json["qtype"] == qtype
 
@@ -169,6 +170,18 @@ def test_nonsense(client: FlaskClient) -> None:
     assert "error" in json
     assert "answer" not in json
     assert "voice" not in json
+
+
+def test_voice_settings_integrity(client: FlaskClient) -> None:
+    """Make sure that the voice ID is returned to client in
+    response to a voice query, and that it is sane."""
+    json = qmcall(client, {"q": "Hver er tilgangur lífsins", "voice": True}, "Special")
+    assert json["voice_id"] == "Gudrun"
+    assert json["voice_locale"] == "is_IS"
+
+    json = qmcall(client, {"q": "Hver er tilgangur lífsins", "voice": True, "voice_id": "Gunnar"}, "Special")
+    assert json["voice_id"] == "Gunnar"
+    assert json["voice_locale"] == "is_IS"
 
 
 def test_arithmetic(client: FlaskClient) -> None:


### PR DESCRIPTION
* API endpoints that require Greynir API key now accept it via Authorization header (and continue to accept it via query param, for legacy reasons)
* Fixed bug in handling user-specified is_IS voice_id in query engine