### PR TITLE
Fix dv.is scraper after Drupal migration; warn on empty article content

### DIFF
--- a/scrapers/default.py
+++ b/scrapers/default.py
@@ -1644,7 +1644,7 @@ class DVScraper(ScrapeHelper):
             heading = heading[: -len(suffix)].strip()
 
         # Extract the publication time from the article:published_time meta property
-        timestamp = _now()
+        timestamp: Optional[datetime] = None
         try:
             ts = ScrapeHelper.meta_property(soup, "article:published_time")
             if ts:
@@ -1660,6 +1660,37 @@ class DVScraper(ScrapeHelper):
         except Exception:
             pass
 
+        if timestamp is None:
+            # The Drupal layout (June 2026 onwards) carries no
+            # article:published_time meta property, no <time> element and no
+            # JSON-LD. The only publication date on the page is the rendered
+            # Icelandic date line, e.g. "Þriðjudaginn 28. júlí 2026 17:30".
+            date_div = ScrapeHelper.div_class(soup, "article-date")
+            if date_div:
+                datestr = date_div.get_text(" ", strip=True)
+                try:
+                    m = re.search(
+                        r"(\d{1,2})\.\s+([^\s]+)\s+(\d{4})(?:\s+(\d{1,2}):(\d{2}))?",
+                        datestr,
+                    )
+                    if m:
+                        timestamp = datetime(
+                            year=int(m.group(3)),
+                            month=MONTHS.index(m.group(2).lower()) + 1,
+                            day=int(m.group(1)),
+                            hour=int(m.group(4) or 0),
+                            minute=int(m.group(5) or 0),
+                            tzinfo=timezone.utc,
+                        )
+                except Exception as e:
+                    logging.warning(
+                        f"Exception obtaining date of dv.is article "
+                        f"from '{datestr}': {e}"
+                    )
+
+        if timestamp is None:
+            timestamp = _now()
+
         metadata.heading = heading
         metadata.author = author
         metadata.timestamp = timestamp
@@ -1668,8 +1699,16 @@ class DVScraper(ScrapeHelper):
 
     def get_content(self, soup: BeautifulSoup) -> Optional[Tag]:
         """Find the article content (main text) in the soup"""
-        content = ScrapeHelper.div_class(soup, "textinn")
+        # dv.is migrated from WordPress to Drupal on 2026-06-18; the article
+        # body is now a 'field--name-body' div. Scope the lookup to the article
+        # node, because the same class is also used by two footer blocks.
+        node = ScrapeHelper.div_class(soup, "node__content")
+        content = ScrapeHelper.div_class(node, "field--name-body") if node else None
         if not content:
+            # Pre-2026-06-18 layout
+            content = ScrapeHelper.div_class(soup, "textinn")
+        if not content:
+            logging.warning("Could not find article content in dv.is article")
             return BeautifulSoup("", _HTML_PARSER)  # Return empty soup.
 
         for t in content.find_all("style"):
@@ -2175,6 +2214,7 @@ class HeimildinScraper(ScrapeHelper):
         """Find the article content (main text) in the soup."""
         content = ScrapeHelper.div_class(soup, "article__body")
         if not content:
+            logging.warning("Could not find article content in heimildin.is article")
             return BeautifulSoup("")
         for elm in content.find_all("figure"):
             elm.decompose()
@@ -2223,5 +2263,6 @@ class SamstodinScraper(ScrapeHelper):
         """Find the article content (main text) in the soup."""
         content = ScrapeHelper.div_class(soup, "entry-content")
         if not content:
+            logging.warning("Could not find article content in samstodin.is article")
             return BeautifulSoup("")
         return content


### PR DESCRIPTION
dv.is migrated from WordPress to Drupal on 2026-06-18. `DVScraper.get_content` looked for `div.textinn`, which no longer exists, and returned an empty soup **silently** — articles were still fetched, stored and marked parsed, but contained no text, so nothing reached the news feed.

Weekly sentence counts for dv.is went from ~7,300 to 0 and stayed there for 40 days without a single error surfacing. ~1,870 articles are affected.

## Changes

- **`get_content`**: find the Drupal body field `div.field--name-body`, scoped to `div.node__content` — the same class is used by two footer blocks, so an unscoped lookup ingests the address and copyright line as article text. Falls back to `div.textinn`, so pre-migration articles still parse.
- **`get_metadata`**: the new layout has no `article:published_time` meta property, no `<time>` element and no JSON-LD, so timestamps were silently defaulting to the scrape time. Parse the rendered Icelandic date line (`div.article-date`) instead, e.g. `"Þriðjudaginn 28. júlí 2026 17:30"`, using the module's existing `MONTHS` table.
- **Log a warning when article content cannot be found** — here and in the `heimildin.is` and `samstodin.is` helpers. The other three empty-soup returns (visir.is live sport, hagstofa.is statistics pages, frettabladid.is sport) are documented intentional cases and are deliberately left silent, so the new warning stays a real signal.

## Verification

Against real stored HTML from the scraper database:

- 5 post-migration articles yield 777–2,011 chars with correct headings and real publication timestamps
- 2 pre-migration articles still parse via the fallback, with authors and meta timestamps intact

Smoke-tested end to end against the live database: 10 recent dv.is articles went from 0 sentences to **192 sentences / 170 parsed (88.5%)**, against a corpus-wide ratio of 87.0%. A parse ratio that healthy indicates the extracted text is well-formed prose rather than markup fragments.

## Post-merge

The scraper cron runs from `~greynir/github/Greynir`, **not** from the nginx deployment, so `scripts/deploy.sh` does not fix ingestion on its own — the branch has to be pulled into that checkout.

Once it is live there, the ~1,870 already-scraped articles need to be put back in the parse queue. They are skipped today because `tree` is an empty string rather than NULL, and `iter_unparsed_articles` filters on `tree == None`:

```sql
UPDATE articles SET tree = NULL
WHERE root_id = (SELECT id FROM roots WHERE domain = 'dv.is')
  AND scraped >= '2026-06-18'
  AND num_sentences = 0;
```

Run this **after** the fix is live, otherwise the next cron run reparses all of them with the old helper and writes the empty trees straight back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
