### PR TITLE
Derive the repo root from each script's own location

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,13 @@
 # set -o nounset   # Disallow unset variables
 # set -o pipefail  # Pipeline command fails if any command fails
 
-SRC=~/github/Greynir
+# Repository root, derived from this script's own location rather than a
+# hardcoded path under $HOME. The old value was ~/github/Greynir, which broke
+# in two ways: it depended on which user ran the script, and it did not survive
+# the repository being renamed from Greynir to GreynirServer. Since errexit is
+# disabled below, a wrong SRC does not abort the run -- it silently deploys
+# whatever happens to be in the current directory instead.
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 MODE="PRODUCTION"
 DEST="/usr/share/nginx/greynir.is" # Production
 SERVICE="greynir"
@@ -34,7 +40,7 @@ fi
 
 echo "Deploying $SRC to $DEST..."
 
-cd $SRC || exit 1
+cd "$SRC" || exit 1
 
 cp requirements.txt $DEST/requirements.txt
 
@@ -51,7 +57,7 @@ echo "Removing binary grammar files"
 rm venv/site-packages/reynir/Greynir.grammar.bin
 rm venv/site-packages/reynir/Greynir.grammar.query.bin
 
-cd $SRC || exit 1
+cd "$SRC" || exit 1
 
 echo "Copying files"
 

--- a/scripts/runreparse.sh
+++ b/scripts/runreparse.sh
@@ -8,7 +8,14 @@ set -o errexit   # Exit when a command fails
 # set -o nounset   # Disallow unset variables
 set -o pipefail  # Pipeline command fails if any command fails
 
-cd ~/Greynir || exit 1
+# Repository root, derived from this script's own location. Previously this was
+# ~/Greynir, which resolved only through the greynir account's
+# ~/Greynir -> github/Greynir symlink. pwd -P resolves that symlink, so SRC is
+# always the real path (~/github/Greynir) no matter how the script is invoked,
+# and the script keeps working if the checkout is renamed.
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+cd "$SRC" || exit 1
 # shellcheck disable=SC1091
 source venv/bin/activate
 GREYNIR_DB_HOST="greynir.is" timeout 120m python scraper.py --reparse --limit=5000

--- a/scripts/runscraper.sh
+++ b/scripts/runscraper.sh
@@ -7,8 +7,15 @@ set -o errexit   # Exit when a command fails
 # set -o nounset   # Disallow unset variables
 set -o pipefail  # Pipeline command fails if any command fails
 
+# Repository root, derived from this script's own location. Previously this was
+# ~/Greynir, which resolved only through the greynir account's
+# ~/Greynir -> github/Greynir symlink. pwd -P resolves that symlink, so SRC is
+# always the real path (~/github/Greynir) no matter how the script is invoked,
+# and the script keeps working if the checkout is renamed.
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
 # Scraper
-cd ~/Greynir || exit 1
+cd "$SRC" || exit 1
 # shellcheck disable=SC1091
 source venv/bin/activate
 GREYNIR_DB_HOST="greynir.is" timeout 20m python scraper.py --limit=2500
@@ -17,7 +24,7 @@ GREYNIR_DB_HOST="greynir.is" timeout 20m python scraper.py --limit=2500
 deactivate
 
 # Processor
-cd ~/Greynir || exit 1
+cd "$SRC" || exit 1
 # shellcheck disable=SC1091
 source venv/bin/activate
 GREYNIR_DB_HOST="greynir.is" timeout 20m python processor.py --limit=3000

--- a/scripts/runtagger.sh
+++ b/scripts/runtagger.sh
@@ -3,8 +3,14 @@
 # Run topic vector tagging program
 #
 
+# Repository root, derived from this script's own location rather than the
+# hardcoded ~/github/Greynir, which depended on both the user running the
+# script and the checkout's directory name. pwd -P resolves any symlink, so
+# SRC is always the real path and this survives a rename of the checkout.
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
 # Tagger
-cd ~/github/Greynir/vectors || exit 1
+cd "$SRC/vectors" || exit 1
 # shellcheck disable=SC1091
 source venv/bin/activate
 GREYNIR_DB_HOST="greynir.is" timeout 20m python builder.py --limit=2500 --notify tag


### PR DESCRIPTION
`scripts/deploy.sh` hardcoded `SRC=~/github/Greynir`; `runscraper.sh` and `runreparse.sh` did `cd ~/Greynir`; `runtagger.sh` did `cd ~/github/Greynir/vectors`. All four were tied to both the invoking user's `$HOME` and the checkout's directory name.

## Why this matters

**`deploy.sh` silently misbehaves for any user but `greynir`.** `SRC` resolves under the caller's `$HOME`, and `set -o errexit` is commented out, so a wrong `SRC` does not abort the run.

**`~/Greynir` only resolves through a symlink.** The `greynir` account has `~/Greynir -> github/Greynir`. The cron scraper depends on it, so renaming the checkout to match this repository's rename from `Greynir` to `GreynirServer` would break `runscraper.sh`, `runreparse.sh` and `runtagger.sh` — silently from the operator's point of view, since a failing cron job leaves nothing in `logs/runscraper.log`.

## The change

```bash
SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
```

`pwd -P` resolves symlinks, so `SRC` is always the real `~/github/Greynir` path rather than the `~/Greynir` alias — the path stays explicit about `/github` without hardcoding it.

## Verification

`bash -n` clean on all four. `SRC` resolution confirmed for four invocation styles against a mimic tree (`<root>/github/Greynir` plus a `<root>/Greynir` symlink):

| invocation | resolves to |
|---|---|
| `scripts/x.sh` (relative) | `…/github/Greynir` |
| `./x.sh` from `scripts/` | `…/github/Greynir` |
| absolute path, any cwd | `…/github/Greynir` |
| **via the `~/Greynir` symlink** | `…/github/Greynir` |

`deploy.sh`'s abort path still exits 1 on a declined confirmation.

## Note for deployment

Nothing here reaches the box until `/home/greynir/github/Greynir` is pulled. Before that pull, confirm how cron invokes these scripts — the derivation reads `${BASH_SOURCE[0]}`, which is correct for absolute, relative, `source`d and via-symlink invocation, but would be empty if cron pipes a script into bash (`bash < runscraper.sh`). The previous `cd ~/Greynir` was immune to invocation form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)