### PR TITLE
Stub speech synthesis in tests; trim the CI matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,11 @@ jobs:
       # single version is exactly when the others' results are most informative.
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "pypy3.11"]
+        # CPython 3.12 and PyPy 3.11 only. Running CPython 3.11 as well was
+        # redundant: PyPy 3.11 implements the 3.11 language level, so the
+        # requires-python = ">=3.11" floor stays covered, and PyPy is the
+        # implementation that actually runs this code in production.
+        python-version: ["3.12", "pypy3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+"""
+
+    Greynir: Natural language processing for Icelandic
+
+    Shared pytest fixtures.
+
+    Copyright (C) 2026 Miðeind ehf.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/.
+
+
+    Speech synthesis is stubbed out for the whole test suite.
+
+    The query tests exercise voice answers heavily, but every assertion they
+    make is about the *text* of the answer -- transcription, number expansion,
+    voice_id and voice_locale. Not one of them inspects the synthesised audio;
+    routes/api.py only takes the returned path and turns it into a URL. The
+    real call nevertheless performed a network round trip to Azure Speech for
+    every voice query, which coupled the suite's pass rate to a third party's
+    latency.
+
+    That is not hypothetical. On 2026-07-30 all three CI legs failed with 24
+    instances of "TTS with Azure failed: Timeout while synthesizing", and a
+    rerun failed a completely different random subset of tests with the same
+    error. No assertion failures either time. A build that reddens for reasons
+    unrelated to the diff trains people to ignore red builds, which is the
+    expensive part.
+
+    Set GREYNIR_TEST_REAL_TTS=1 to restore the real Azure/Polly path, e.g. when
+    deliberately testing the speech integration itself.
+
+"""
+
+from typing import Any, Iterator
+
+import os
+import uuid
+
+import pytest
+
+
+def _use_real_tts() -> bool:
+    return bool(os.environ.get("GREYNIR_TEST_REAL_TTS"))
+
+
+@pytest.fixture(autouse=True)
+def stub_tts(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Replace speech synthesis with a stub returning a plausible file path.
+
+    Patches the name bound in routes.api rather than icespeak itself, so the
+    substitution is visible exactly where the application calls it and nothing
+    else in icespeak is disturbed.
+    """
+    if _use_real_tts():
+        yield
+        return
+
+    # Imported here rather than at module scope, deliberately. Both routes and
+    # icespeak are heavy application imports, and icespeak in particular
+    # constructs its pydantic Settings at import time. Under pydantic-settings
+    # 2.2+ that construction raises if the working directory holds a .env
+    # containing any key not prefixed ICESPEAK_ -- an OPENAI_API_KEY in a
+    # developer's local .env is enough. Keeping these imports out of conftest's
+    # module scope means such a failure cannot break collection of the many
+    # tests that never touch speech at all.
+    import routes.api
+    from icespeak.tts import TTSOutput
+
+    from utility import TTS_AUDIO_DIR
+
+    def _fake_tts_to_file(text: str, *args: Any, **kwargs: Any) -> "TTSOutput":
+        # The path is never opened -- routes.api calls .as_uri() on it and
+        # rewrites that into an http(s) URL. Keep it under TTS_AUDIO_DIR so the
+        # 'static/audio/' rewrite in _audio_file_url_to_host_url still applies,
+        # exercising the same code path as a real synthesis would.
+        return TTSOutput(file=TTS_AUDIO_DIR / f"{uuid.uuid4()}.mp3", text=text)
+
+    monkeypatch.setattr(routes.api, "tts_to_file", _fake_tts_to_file)
+    yield


### PR DESCRIPTION
## The problem

Every voice query in the test suite performed a **real network round trip to Azure Speech** via `routes.api`'s `tts_to_file`. That coupled the suite's pass rate to a third party's latency.

On 2026-07-30 this blocked #224 — a shell-scripts-only change — by failing **all three CI legs** with 24 instances of:

```
RuntimeError: TTS with Azure failed: Timeout while synthesizing.
  Current RTF: 7.18571 (threshold 2), frame interval 3018ms (threshold 3000ms)
```

A rerun failed a *different* random subset of tests with the same error. Neither run produced a single assertion failure. The tell was that the failing set differed per interpreter leg — a genuine regression fails the same tests everywhere.

## Why stubbing loses no coverage

Every assertion these tests make is about the **text** of the answer:

```python
assert _has_no_numbers(json["voice"])
assert "tvö þúsund" in json["voice"]
assert json["voice_id"] == "Gudrun"
```

That text is produced by the query modules and icespeak's transcription layer, neither of which is stubbed. Nothing inspects the synthesised audio — `qmcall` never asserts on `audio`, and no test in the suite references `audio` or `audio_url`. `routes.api` only calls `.as_uri()` on the returned path and rewrites it into an http URL.

## The change

`tests/conftest.py` adds an autouse fixture patching `routes.api.tts_to_file` — the name bound where the application calls it, leaving icespeak itself untouched. The stub returns a path under `TTS_AUDIO_DIR` so the `static/audio/` rewrite in `_audio_file_url_to_host_url` is still exercised.

`GREYNIR_TEST_REAL_TTS=1` restores the real Azure/Polly path for deliberately testing the speech integration.

Imports of `routes` and `icespeak` are inside the fixture rather than at module scope: icespeak builds its pydantic `Settings` at import time, and under pydantic-settings 2.2+ that raises if the working directory holds a `.env` with any non-`ICESPEAK_`-prefixed key — an `OPENAI_API_KEY` in a local `.env` is enough. At module scope that would break collection of every test, including those that never touch speech.

## Verification

Run via `scripts/test_local.sh` against a disposable PostgreSQL cluster:

| | before | after |
|---|---|---|
| result | 53 passed, 7 skipped | **53 passed, 7 skipped** |
| runtime | 152.8s | **59.7s** |

Identical outcomes, 61% faster. The five tests Azure had been failing across the two CI runs (`test_time`, `test_date`, `test_arithmetic`, `test_bus`, `test_words`) were run in isolation first and all pass.

## CI matrix

Drops CPython 3.11, leaving `["3.12", "pypy3.11"]`. PyPy 3.11 implements the 3.11 language level, so the `requires-python = ">=3.11"` floor stays covered; only CPython-specific 3.11 behaviour goes untested, and nothing runs CPython 3.11 here. PyPy is the implementation that actually serves this code in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)