### PR TITLE
deploy.sh: fail closed when the user cannot deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,6 +31,37 @@ if [[ "$1" = "staging" ]]; then
     SERVICE="staging"
 fi
 
+# Fail closed before doing anything, rather than part way through.
+#
+# errexit is disabled above, so a user who cannot write the deployment would
+# otherwise watch every cp and pip install fail in turn while the script
+# carried on regardless -- and still reach the `sudo systemctl restart` at the
+# end, restarting the service after copying nothing. Deriving SRC from the
+# script's own location made that reachable: the previous hardcoded
+# SRC=~/github/Greynir aborted at `cd $SRC` for anyone but the deployment
+# owner, which failed closed by accident rather than by design.
+#
+# Checking $DEST alone is not enough. On production it is group-writable
+# (drwxrwxr-x greynir:greynir), so anyone in the greynir group passes, while
+# the files inside -- owned by greynir, mode 0644/0755 -- do not. Test the
+# things actually written instead.
+if [[ ! -f "$SRC/main.py" ]]; then
+    echo "Error: $SRC does not look like a Greynir checkout (no main.py)." >&2
+    exit 1
+fi
+
+for target in "$DEST" "$DEST/main.py" "$DEST/config" "$DEST/scrapers"; do
+    if [[ ! -e "$target" ]]; then
+        echo "Error: $target does not exist. Is $DEST a deployment?" >&2
+        exit 1
+    fi
+    if [[ ! -w "$target" ]]; then
+        echo "Error: $target is not writable by $(id -un)." >&2
+        echo "Run scripts/deploy.sh as the user owning the deployment (greynir)." >&2
+        exit 1
+    fi
+done
+
 read -rp "This will deploy Greynir to **${MODE}**. Confirm? (y/n): " CONFIRMED
 
 if [[ "$CONFIRMED" != "y" ]]; then


### PR DESCRIPTION
Follow-up to #224, closing a hazard that change introduced.

## The problem

`SRC=~/github/Greynir` used to make `deploy.sh` fail closed for anyone but the deployment owner — that path doesn't exist under another user's home, so it aborted at `cd $SRC`. Accidental, but effective. Deriving `SRC` from the script's own location removed it: the script now resolves to whatever checkout it sits in and proceeds.

That matters because `set -o errexit` is commented out. Running it as the wrong user, every `cp` and `pip install` fails on permissions, the script continues regardless, and it still reaches:

```bash
sudo systemctl restart $SERVICE
```

On production that's a **~76 second outage from a deployment that copied nothing** — and any member of the `sudo` group can authorise it.

## The check

Verify up front that `$SRC` is a checkout and that the paths actually written are writable, before the confirmation prompt.

Checking `$DEST` alone is insufficient, which is the non-obvious part:

```
/usr/share/nginx/greynir.is           drwxrwxr-x greynir:greynir   <- group-writable, villi PASSES
/usr/share/nginx/greynir.is/main.py   -rwxr-xr-x greynir:greynir   <- villi fails here
```

Anyone in the `greynir` group clears the directory check while every file inside remains unwritable. So the guard tests `$DEST`, `$DEST/main.py`, `$DEST/config` and `$DEST/scrapers`.

## Verification

As `villi`, both modes abort before prompting:

```
$ bash scripts/deploy.sh
Error: /usr/share/nginx/greynir.is/main.py is not writable by villi.
Run scripts/deploy.sh as the user owning the deployment (greynir).

$ bash scripts/deploy.sh staging
Error: /usr/share/nginx/staging.greynir.is is not writable by villi.
```

Production is caught at `main.py` and staging at `$DEST` — the two different paths, confirming both layers of the check do work.

All four paths are `greynir`-owned with owner write, so `greynir` passes every check. `shellcheck -x scripts/*.sh` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)